### PR TITLE
CAT-279 Updating change URL

### DIFF
--- a/EP.PowerShell.JiraDeployInfo/Public/Update-AzureDeploymentInformation.ps1
+++ b/EP.PowerShell.JiraDeployInfo/Public/Update-AzureDeploymentInformation.ps1
@@ -87,12 +87,12 @@ function Update-AzureDeploymentInformation {
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [string]
-        $EnvironmentId = $env:ENVIRONMENT_ID,
+        $EnvironmentId = $env:RELEASE_ENVIRONMENTID,
 
         [Parameter(Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [string]
-        $EnvironmentDisplayName = $env:ENVIRONMENT_NAME,
+        $EnvironmentDisplayName = $env:RELEASE_ENVIRONMENTNAME,
 
         [ValidateSet("Unmapped", "Development", "Testing", "Staging", "Production")]
         [string] $EnvironmentType = "Unmapped",
@@ -116,7 +116,7 @@ function Update-AzureDeploymentInformation {
         [string] $SystemAccessToken = $env:SYSTEM_ACCESSTOKEN,
 
         [Parameter(Mandatory=$false)][ValidateNotNullOrEmpty()]
-        [string] $AzureChangeUrl = "$env:SYSTEM_COLLECTIONURI/$env:SYSTEM_TEAMPROJECT/_traceability/runview/changes?currentRunId=$($env:BUILD_BUILDID)&__rt=fps"
+        [string] $AzureChangeUrl = "$env:SYSTEM_TASKDEFINITIONSURI/$env:SYSTEM_TEAMPROJECT/_traceability/runview/changes?currentRunId=$($env:BUILD_BUILDID)&__rt=fps"
     )
 
     $jiraIds = @()


### PR DESCRIPTION
The value being retrieved from the env vars is prefixed with vsts, which doesn't seem to work anymore. Switching it to a URL which does.

Also updating enviroment ID and name to pull from the standard build vars to avoid having to set them against each pipeline environment.